### PR TITLE
Add meson.options to the list of files to highlight

### DIFF
--- a/meson.sublime-syntax
+++ b/meson.sublime-syntax
@@ -7,6 +7,7 @@ version: 2
 
 file_extensions:
   - meson.build
+  - meson.options
   - meson_options.txt
 
 variables:


### PR DESCRIPTION
Hello @Monochrome-Sauce 

Thanks a lot for creating this plugin!

Since Meson 1.1 option files should be called `meson.options` (see https://mesonbuild.com/Build-options.html#build-options). I added this file extension to the list so that they are automatically syntax-highlighted by the plugin.