### PR TITLE
Add file_regex for error markup

### DIFF
--- a/sublime-builds/Meson Compile.sublime-build
+++ b/sublime-builds/Meson Compile.sublime-build
@@ -1,5 +1,6 @@
 {
 	"keyfiles": ["meson.build"],
+	"name": "Meson compile"
 
 	"syntax": "meson-output.sublime-syntax",
 	"working_dir": "$folder/meson-build",

--- a/sublime-builds/Meson Compile.sublime-build
+++ b/sublime-builds/Meson Compile.sublime-build
@@ -1,7 +1,8 @@
 {
 	"keyfiles": ["meson.build"],
-	
+
 	"syntax": "meson-output.sublime-syntax",
 	"working_dir": "$folder/meson-build",
 	"cmd": ["meson", "compile"],
+	"file_regex": "^\\s*(\\S[^:]*):(\\d+):(\\d+): ([^\\n]+)",
 }

--- a/sublime-builds/Meson Compile.sublime-build
+++ b/sublime-builds/Meson Compile.sublime-build
@@ -1,7 +1,5 @@
 {
 	"keyfiles": ["meson.build"],
-	"name": "Meson compile"
-
 	"syntax": "meson-output.sublime-syntax",
 	"working_dir": "$folder/meson-build",
 	"cmd": ["meson", "compile"],

--- a/sublime-builds/Meson Setup.sublime-build
+++ b/sublime-builds/Meson Setup.sublime-build
@@ -1,7 +1,5 @@
 {
 	"keyfiles": ["meson.build"],
-	"name": "Meson setup"
-
 	"syntax": "meson-output.sublime-syntax",
 	"working_dir": "$folder",
 	"cmd": ["meson", "setup", "meson-build"],

--- a/sublime-builds/Meson Setup.sublime-build
+++ b/sublime-builds/Meson Setup.sublime-build
@@ -1,6 +1,7 @@
 {
 	"keyfiles": ["meson.build"],
-	
+	"name": "Meson setup"
+
 	"syntax": "meson-output.sublime-syntax",
 	"working_dir": "$folder",
 	"cmd": ["meson", "setup", "meson-build"],

--- a/sublime-builds/Meson Test.sublime-build
+++ b/sublime-builds/Meson Test.sublime-build
@@ -1,0 +1,8 @@
+{
+	"keyfiles": ["meson.build"],
+	"name": "Meson test"
+
+	"syntax": "meson-output.sublime-syntax",
+	"working_dir": "$folder/meson-build",
+	"cmd": ["meson", "test"],
+}

--- a/sublime-builds/Meson Test.sublime-build
+++ b/sublime-builds/Meson Test.sublime-build
@@ -1,7 +1,5 @@
 {
 	"keyfiles": ["meson.build"],
-	"name": "Meson test"
-
 	"syntax": "meson-output.sublime-syntax",
 	"working_dir": "$folder/meson-build",
 	"cmd": ["meson", "test"],


### PR DESCRIPTION
This should allow Sublime Text to mark errors in the code:

![image](https://github.com/Monochrome-Sauce/sublime-meson/assets/1677436/2760c2fa-d660-4bf0-ba1a-0e07bab76085)
